### PR TITLE
(AST-133418) Filter OS-owned language packages via ownership-by-file-overlap

### DIFF
--- a/pkg/syftPackagesExtractor/syft_extractor_test.go
+++ b/pkg/syftPackagesExtractor/syft_extractor_test.go
@@ -28,7 +28,7 @@ func TestSyftExtractor(t *testing.T) {
 			Packages       int
 			ImageLocations int
 		}{
-			"rabbitmq:3":               {Layers: 9, Packages: 101, ImageLocations: 1},
+			"rabbitmq:3":               {Layers: 9, Packages: 99, ImageLocations: 1},
 			"golang:1.21.5-alpine3.18": {Layers: 4, Packages: 38, ImageLocations: 1},
 		}
 
@@ -75,7 +75,7 @@ func TestSyftExtractor(t *testing.T) {
 			Packages       int
 			ImageLocations int
 		}{
-			"rabbitmq:3": {Layers: 9, Packages: 101, ImageLocations: 2},
+			"rabbitmq:3": {Layers: 9, Packages: 99, ImageLocations: 2},
 		}
 
 		checkResults(t, resolutions, expectedValues)
@@ -149,7 +149,7 @@ func TestSyftExtractor(t *testing.T) {
 		assert.NotNil(t, successResolution, "Should have one successful resolution")
 		assert.Equal(t, "rabbitmq:3", successResolution.ContainerImage.ImageId)
 		assert.Equal(t, 9, len(successResolution.ContainerImage.Layers))
-		assert.Equal(t, 101, len(successResolution.ContainerPackages))
+		assert.Equal(t, 99, len(successResolution.ContainerPackages))
 		assert.Equal(t, 1, len(successResolution.ContainerImage.ImageLocations))
 
 		// Check the failed resolution


### PR DESCRIPTION
## Summary
- Filters out language-level packages (pip, npm, etc.) that are owned by OS packages (RPM/APK/DPKG) via syft's `ownership-by-file-overlap` relationships from the SBOM
- Uses `artifact.OwnershipByFileOverlapRelationship` constant from the syft library to identify ownership relationships
- Prevents false positive vulnerabilities from upstream CVE databases when the OS vendor has already backported fixes tracked via OVAL advisories

## Test plan
- [x] 7 unit tests covering RPM/APK/DEB ownership, non-OS parents, other relationship types, empty relationships
- [x] All existing tests pass (backward compatible — no filtering when no relationships present)
- [ ] CI pipeline passes

Made with [Cursor](https://cursor.com)